### PR TITLE
2.1.3: Fix concurrency bug in old_linked_files.

### DIFF
--- a/capistrano-linked-files.gemspec
+++ b/capistrano-linked-files.gemspec
@@ -3,7 +3,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |s|
   s.name          = 'capistrano-linked-files'
-  s.version       = '2.1.2'
+  s.version       = '2.1.3'
   s.summary       = 'Upload linked files and directories.'
   s.description   = 'Adds tasks to upload your linked files and directories. '
 

--- a/lib/capistrano/linked_files.rb
+++ b/lib/capistrano/linked_files.rb
@@ -1,1 +1,2 @@
+Capistrano::LinkedFiles = Mutex.new
 load File.expand_path('../tasks/linked_files.rake', __FILE__)

--- a/lib/capistrano/tasks/linked_files.rake
+++ b/lib/capistrano/tasks/linked_files.rake
@@ -15,8 +15,12 @@ namespace :linked_files do
 
   task :concat_linked_config_files do
     on roles :all do
-      set :old_linked_files, fetch(:linked_files,[])
-      set :linked_files, (fetch(:config_files,[]) + (fetch(:linked_files,[]))).uniq
+      Capistrano::LinkedFiles.synchronize do
+        unless fetch(:old_linked_files, false)
+          set :old_linked_files, fetch(:linked_files,[])
+          set :linked_files, (fetch(:config_files,[]) + (fetch(:linked_files,[]))).uniq
+        end
+      end
     end
   end
 


### PR DESCRIPTION
:old_linked_files was getting updated N times, where N
is the number of servers being deployed to.

This was a problem because :config_files is relative to upload/:stage
but :old_linked_files isn't, even though :old_linked_files includes
:config_files when N > 1.